### PR TITLE
Correct <br /> tags

### DIFF
--- a/handlers/notification/mailer.rb
+++ b/handlers/notification/mailer.rb
@@ -123,22 +123,22 @@ class Mailer < Sensu::Handler
     bodyhtml = <<-BODYHTML.gsub(/^\s+/, '')
 
             <b>#{@event['check']['output']}</b>
-            </br>
-            </br>
+            <br />
+            <br />
             Admin GUI: #{admin_gui}
-            </br>
+            <br />
             Host: #{@event['client']['name']}
-            </br>
+            <br />
             Timestamp: #{Time.at(@event['check']['issued'])}
-            </br>
+            <br />
             Address:  #{@event['client']['address']}
-            </br>
+            <br />
             Check Name:  #{@event['check']['name']}
-            </br>
+            <br />
             Command:  #{command}
-            </br>
+            <br />
             Status:  #{status_to_string}
-            </br>
+            <br />
             Occurrences:  #{@event['occurrences']}
             #{playbook}
 


### PR DESCRIPTION
Emails are now correcly shown also in Gmail.
![screenshot from 2015-09-24 16 49 19](https://cloud.githubusercontent.com/assets/160299/10076564/79f7c3d6-62dc-11e5-8bbd-36dca995ae77.png)
