### PR TITLE
Trying to break known CPU patterns

### DIFF
--- a/plugins/system/cpu-pcnt-usage-metrics.rb
+++ b/plugins/system/cpu-pcnt-usage-metrics.rb
@@ -57,6 +57,9 @@ class CpuGraphite < Sensu::Plugin::Metric::CLI::Graphite
   end
 
   def run
+    # sleeping a random amount of time to break well known CPU pattern (EG: systems with cron jobs)
+    sleep(Random.new.rand(0..5))
+
     cpu_sample1 = acquire_proc_stats
     sleep(1)
     cpu_sample2 = acquire_proc_stats


### PR DESCRIPTION
In systems with a well known CPU usage patterns (like for example systems with lots of cron jobs running each 10 seconds) there is the risk that the check is perfectly in sync with the CPU peaks and the metric results to be strongly biased towards the CPU usage pattern.
With some randomness we hope to break the pattern.
